### PR TITLE
Fix #28

### DIFF
--- a/statushud/elements/room.cs
+++ b/statushud/elements/room.cs
@@ -14,6 +14,7 @@ public class StatusHudRoomElement : StatusHudElement
     private readonly IClientWorldAccessor world;
     private readonly RoomRegistry roomRegistry;
     private readonly Thread roomUpdateThread;
+    private readonly int updateInterval;
     private volatile bool isRunning;
 
     private BlockPos currentPosition;
@@ -33,6 +34,9 @@ public class StatusHudRoomElement : StatusHudElement
         this.system.capi.Event.RegisterRenderer(renderer, EnumRenderStage.Ortho);
         world = system.capi.World;
         roomRegistry = world.Api.ModLoader.GetModSystem<RoomRegistry>();
+
+        // Match the update interval to the tick frequency
+        updateInterval = fast ? StatusHudSystem.FastListenInterval : StatusHudSystem.SlowListenInterval;
 
         // Start background thread for room updates
         isRunning = true;
@@ -79,8 +83,8 @@ public class StatusHudRoomElement : StatusHudElement
                     _isGreenhouse = room?.SkylightCount > room?.NonSkylightCount;
                 }
 
-                // Update every 100ms
-                Thread.Sleep(100);
+                // Sleep for the appropriate interval (matches tick frequency)
+                Thread.Sleep(updateInterval);
             }
         }
         catch (ThreadInterruptedException)

--- a/statushud/elements/room.cs
+++ b/statushud/elements/room.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Threading;
 using Vintagestory.API.Client;
+using Vintagestory.API.MathTools;
 using Vintagestory.GameContent;
 
 namespace StatusHud;
@@ -9,13 +12,36 @@ public class StatusHudRoomElement : StatusHudElement
     private readonly StatusHudRoomRenderer renderer;
 
     private readonly IClientWorldAccessor world;
-    internal Room room;
+    private readonly RoomRegistry roomRegistry;
+    private readonly Thread roomUpdateThread;
+    private volatile bool isRunning;
+
+    private BlockPos currentPosition;
+
+    // Thread-safe room state flags using volatile for atomic reads/writes
+    private volatile bool _inRoom;
+    private volatile bool _isSmallRoom;
+    private volatile bool _isGreenhouse;
+
+    internal bool InRoom => _inRoom;
+    internal bool IsSmallRoom => _isSmallRoom;
+    internal bool IsGreenhouse => _isGreenhouse;
 
     public StatusHudRoomElement(StatusHudSystem system) : base(system)
     {
         renderer = new StatusHudRoomRenderer(system, this);
         this.system.capi.Event.RegisterRenderer(renderer, EnumRenderStage.Ortho);
         world = system.capi.World;
+        roomRegistry = world.Api.ModLoader.GetModSystem<RoomRegistry>();
+
+        // Start background thread for room updates
+        isRunning = true;
+        roomUpdateThread = new Thread(RoomUpdateLoop)
+        {
+            Name = "StatusHud-RoomUpdate",
+            IsBackground = true
+        };
+        roomUpdateThread.Start();
     }
 
     public override string ElementName => Name;
@@ -31,11 +57,56 @@ public class StatusHudRoomElement : StatusHudElement
         {
             return;
         }
-        room = world.Api.ModLoader.GetModSystem<RoomRegistry>().GetRoomForPosition(world.Player.Entity.Pos.AsBlockPos);
+
+        // Just update the position to check
+        currentPosition = world.Player.Entity.Pos.AsBlockPos;
+    }
+
+    private void RoomUpdateLoop()
+    {
+        try
+        {
+            while (isRunning)
+            {
+                BlockPos pos = currentPosition;
+                if (pos != null)
+                {
+                    Room room = roomRegistry.GetRoomForPosition(pos);
+
+                    // Atomic writes via volatile fields
+                    _inRoom = room?.ExitCount == 0;
+                    _isSmallRoom = room?.IsSmallRoom == true;
+                    _isGreenhouse = room?.SkylightCount > room?.NonSkylightCount;
+                }
+
+                // Update every 100ms
+                Thread.Sleep(100);
+            }
+        }
+        catch (ThreadInterruptedException)
+        {
+            // Thread was interrupted, exit gracefully
+        }
+        catch (Exception ex)
+        {
+            system.capi.Logger.Error($"[StatusHud] Room update thread error: {ex}");
+        }
     }
 
     public override void Dispose()
     {
+        isRunning = false;
+
+        // Wait for thread to stop (with timeout)
+        if (roomUpdateThread?.IsAlive == true)
+        {
+            roomUpdateThread.Interrupt();
+            if (!roomUpdateThread.Join(TimeSpan.FromSeconds(2)))
+            {
+                system.capi.Logger.Warning("[StatusHud] Room update thread did not stop in time");
+            }
+        }
+
         renderer.Dispose();
         system.capi.Event.UnregisterRenderer(renderer, EnumRenderStage.Ortho);
     }
@@ -58,17 +129,15 @@ public class StatusHudRoomRenderer : StatusHudRenderer
 
     protected override void Render()
     {
-        if (element.room is { ExitCount: 0 })
+        if (element.InRoom)
         {
             // Inside.
-            Room room = element.room;
-
             system.capi.Render.RenderTexture(
-                room.IsSmallRoom ? system.textures.TexturesDict["room_cellar"].TextureId : system.textures.TexturesDict["room_room"].TextureId, x,
+                element.IsSmallRoom ? system.textures.TexturesDict["room_cellar"].TextureId : system.textures.TexturesDict["room_room"].TextureId, x,
                 y, w, h);
 
             // No room flag available, based on FruitTreeRootBH.
-            if (room.SkylightCount > room.NonSkylightCount)
+            if (element.IsGreenhouse)
             {
                 system.capi.Render.RenderTexture(system.textures.TexturesDict["room_greenhouse"].TextureId, x, ghy, w, h);
             }

--- a/statushud/system.cs
+++ b/statushud/system.cs
@@ -15,8 +15,8 @@ public class StatusHudSystem : ModSystem
 {
     public const string Domain = "statushudcont";
     public const int IconSize = 32;
-    private const int slowListenInterval = 1000;
-    private const int fastListenInterval = 100;
+    public const int SlowListenInterval = 1000;
+    public const int FastListenInterval = 100;
 
     public ICoreClientAPI capi;
 
@@ -78,8 +78,8 @@ public class StatusHudSystem : ModSystem
             configManager.LoadElements(this);
         }
 
-        slowListenerId = this.capi.Event.RegisterGameTickListener(SlowTick, slowListenInterval);
-        fastListenerId = this.capi.Event.RegisterGameTickListener(FastTick, fastListenInterval);
+        slowListenerId = this.capi.Event.RegisterGameTickListener(SlowTick, SlowListenInterval);
+        fastListenerId = this.capi.Event.RegisterGameTickListener(FastTick, FastListenInterval);
 
         capi.Event.PlayerJoin += SetUuid;
         // Used to check for new elements for other mods


### PR DESCRIPTION
Move the room registry accesses off to a dedicated thread so that the block accessor works as expected. In my testing, this fixed crashes when I have the room element enabled.