### PR TITLE
Fixes #37 - Updates rift activity timer to use Calendar.ElapsedHours

### DIFF
--- a/statushud/elements/rift_activity.cs
+++ b/statushud/elements/rift_activity.cs
@@ -90,7 +90,7 @@ public class StatusHudRiftActivityElement : StatusHudElement
 
         if (showRiftChange.ToLower().ToBool())
         {
-            double hours = system.capi.World.Calendar.TotalHours;
+            double hours = system.capi.World.Calendar.ElapsedHours;
             double nextRiftChange = Math.Max(_riftActivityData.UntilTotalHours - hours, 0);
 
             TimeSpan ts = TimeSpan.FromHours(nextRiftChange);


### PR DESCRIPTION
Fixes #37 - Updates rift activity timer to use `Calendar.ElapsedHours`. This reflects changes made in anegostudios/vssurvivalmod@4cce538f33bdd3cfd3f53bfbd079287e75595485 to `RiftWeather.cs`. Tested locally, this fixes the timer to count down as expected.